### PR TITLE
fix(component readme): fix alt text, fix broken image urls

### DIFF
--- a/design-guide/components/README.md
+++ b/design-guide/components/README.md
@@ -4,7 +4,7 @@
 
 Microapps should always come with an app bar.
 
-![App Bar](https://rawgit.com/allthings/developers/design.guide/design-guide/components/assets/app.bar.svg)
+![App Bar](https://raw.githubusercontent.com/allthings/developers/master/design-guide/components/assets/app.bar.svg?sanitize=true)
 
 ## Fluid Layout
 
@@ -19,21 +19,21 @@ rectangular.
 ## Example MicroApps
 
 ### Pinboard
-![Who is Who](assets/example.pinboard.png)
+![Pinboard](https://github.com/allthings/developers/blob/master/design-guide/components/assets/example.pinboard.png?raw=true)
 
 ****
 
 ### Who is who
-![Who is Who](assets/example.whoiswho.png)
+![Who is Who](https://github.com/allthings/developers/blob/master/design-guide/components/assets/example.whoiswho.png?raw=true)
 
 ****
 
 ### Energy Consumption
-![Energy Consumption](assets/example.energy.png)
+![Energy Consumption](https://github.com/allthings/developers/blob/master/design-guide/components/assets/example.energy.png?raw=true)
 
 ****
 
 ### Settings Page
-![Settings](assets/example.settings.png)
+![Settings](https://github.com/allthings/developers/blob/master/design-guide/components/assets/example.settings.png?raw=true)
 
 ****


### PR DESCRIPTION
@fivenp I noticed these were broken when I was looking through the other day and so this should fix them up. The images work fine within github but on the page: https://developers.allthings.me/developers/design-guide/components/index.html they still show as broken. The SVG was broken on both. Also as an FYI GitRaw.com is also at end of life and will stop serving soon, do we need to update anything else?